### PR TITLE
 Changes external links due to missing spaces #2

### DIFF
--- a/views/features.dt
+++ b/views/features.dt
@@ -134,11 +134,11 @@ block vibed.body
 			p Using asynchronous I/O has several advantages, the main point being that the memory overhead is much lower. This is because only a single hardware thread is needed to handle an arbitrary number of concurrent operations. The thread typically rests waiting for events and is woken up by the operating system as soon as new data arrives, a new connection is established, or an error occurs. After each initiated blocking operation (e.g. writing data to a socket), the thread will go back to sleep and let the operating system execute the operation in the background.
 
 			p Another important aspect for speed is that, because there is only one or a few threads necessary, it is often possible to save a lot of expensive thread context switches. However, note that if the application has to do a lot of computations apart from the actual I/O operations, vibe.d has full support for
-				a(href="#multi-threading") multi-threading
+				#[a(href="#multi-threading") multi-threading]
 				| to fully exploit the system's multi-core CPU.
 
 			p Because using the asynchronous event based model is often more involved regarding the application implementation,
-				a(href="#fibers") fibers
+				#[a(href="#fibers") fibers]
 				| are used together with an event based scheduler to give the impression of classic blocking calls and multi-threading, thus hiding the additional complexities, while retaining the performance characteristics of asynchronous I/O.
 
 		section
@@ -169,7 +169,7 @@ block vibed.body
 			p Vibe.d is written in the <a class="extern" href="https://dlang.org" target="_blank">D Programming Language</a>. D is a C-style language that compiles down to native machine code with minimal runtime overhead. In addition to being fast, D offers a number of features that allow additional performance improvements and especially code readability, safety and usability improvements compared to other languages such as C++.
 
 			p Some notable features are listed here, but there are a lot of additional things which would be beyond the scope of this text. See the
-				a.extern(href="https://dlang.org/comparison.html", target="_blank") D feature page
+				#[a.extern(href="https://dlang.org/comparison.html", target="_blank") D feature page]
 				| or the <a class="extern" href="https://ddili.org/ders/d.en/index.html" target="_blank">Programming in D</a> online book for a more general overview.
 
 			dl.feat


### PR DESCRIPTION
Please check diet syntax. Spaces where missing before and/or after links.